### PR TITLE
3D Momentum and Magnetic components for 2D

### DIFF
--- a/src_mhd/assemble_explicit.cc
+++ b/src_mhd/assemble_explicit.cc
@@ -52,7 +52,9 @@ void ConservationLaw<dim>::integrate_cell_term_explicit
    typedef double FluxMatrix[MHDEquations<dim>::n_components][dim];
    FluxMatrix *flux = new FluxMatrix[n_q_points];
    
-   std::vector<Vector<double> > ext_force_values(n_q_points, Vector<double>(dim));
+   //std::vector<Vector<double> > ext_force_values(n_q_points, Vector<double>(dim));
+   std::vector<Vector<double> > ext_force_values(n_q_points,
+						 Vector<double>(MHDEquations<dim>::v_components));
    parameters.external_force.vector_value_list(fe_v.get_quadrature_points(),
                                                ext_force_values);
    

--- a/src_mhd/equation.cc
+++ b/src_mhd/equation.cc
@@ -246,7 +246,10 @@ MHDEquations<dim>::Postprocessor::get_names () const
   names.push_back ("XVelocity");
   names.push_back ("YVelocity");
   if(dim==3)
-     names.push_back ("ZVelocity");
+    names.push_back ("ZVelocity");
+  //names.push_back ("XMagnetic");
+  //names.push_back ("YMagnetic");
+  //names.push_back ("ZMagnetic");
   names.push_back ("Pressure");
 
   if (do_schlieren_plot == true)

--- a/src_mhd/ic.cc
+++ b/src_mhd/ic.cc
@@ -55,10 +55,11 @@ void IsentropicVortex<dim>::vector_value (const Point<dim> &p,
    
    values[MHDEquations<dim>::momentum_component] = rho * vex;
    values[MHDEquations<dim>::momentum_component+1] = rho * vey;
+   values[MHDEquations<dim>::momentum_component+2] = 0;
    values[MHDEquations<dim>::density_component] = rho;
    values[MHDEquations<dim>::energy_component] = pre/(gamma-1.0)
                                                    + 0.5 * rho * (vex*vex + vey*vey);
-   for(unsigned int i=0; i<dim; ++i)
+   for(unsigned int i=0; i<MHDEquations<dim>::v_components; ++i)
      values[MHDEquations<dim>::magnetic_component+i] = 0;
 }
 
@@ -92,10 +93,11 @@ void VortexSystem<dim>::vector_value (const Point<dim> &p,
    
    values[MHDEquations<dim>::momentum_component] = rho * vex;
    values[MHDEquations<dim>::momentum_component+1] = rho * vey;
+   values[MHDEquations<dim>::momentum_component+2] = 0;
    values[MHDEquations<dim>::density_component] = rho;
    values[MHDEquations<dim>::energy_component] = pre/(gamma-1.0)
                                                  + 0.5 * rho * (vex*vex + vey*vey);
-   for(unsigned int i=0; i<dim; ++i)
+   for(unsigned int i=0; i<MHDEquations<dim>::v_components; ++i)
      values[MHDEquations<dim>::magnetic_component+i]=0;
 }
 

--- a/src_mhd/parameters.cc
+++ b/src_mhd/parameters.cc
@@ -321,7 +321,7 @@ namespace Parameters
    template <int dim>
    AllParameters<dim>::AllParameters ()
    :
-   external_force (dim),
+   external_force (MHDEquations<dim>::v_components),
    initial_conditions (MHDEquations<dim>::n_components)
    {}
    
@@ -363,7 +363,8 @@ namespace Parameters
                         "gravitational force");
       
       // Components of external force
-      for(int d=0; d<dim; ++d)
+      //for(int d=0; d<dim; ++d)
+      for(int d=0; d<MHDEquations<dim>::v_components; ++d)
          prm.declare_entry("f_" + Utilities::int_to_string(d) +
                            " value", "0.0",
                            Patterns::Anything(),
@@ -496,8 +497,9 @@ namespace Parameters
       if(dim==3) variables = "x,y,z,t";
       
       // External force
-      std::vector<std::string> force_expressions(dim, "0.0");
-      for(unsigned int d=0; d<dim; ++d)
+      //std::vector<std::string> force_expressions(dim, "0.0");
+      std::vector<std::string> force_expressions(MHDEquations<dim>::v_components, "0.0");
+      for(unsigned int d=0; d<MHDEquations<dim>::v_components; ++d)
          force_expressions[d] = prm.get("f_" + Utilities::int_to_string(d) +
                                         " value");
       external_force.initialize(variables,


### PR DESCRIPTION
This commit ensures that for MHD, even if the number of space dimensions are 2, it is required to calculate all the 3 components of the momentum and the magnetic field.