### PR TITLE
DG MHD for smooth cases including Powell terms

### DIFF
--- a/examples/AlfvenWave/grid.geo
+++ b/examples/AlfvenWave/grid.geo
@@ -1,7 +1,10 @@
-ny = 20;
-nx = 2*ny;
-lx = Sqrt(5);
-ly = 0.5*lx;
+ny = 128;
+nx = 128;
+//lx = Sqrt(5);
+//ly = 0.5*lx;
+
+lx = 1;
+ly = 1;
 
 Point(1) = { 0,  0, 0};
 Point(2) = {lx,  0, 0};

--- a/examples/AlfvenWave/grid.geo
+++ b/examples/AlfvenWave/grid.geo
@@ -1,0 +1,31 @@
+ny = 20;
+nx = 2*ny;
+lx = Sqrt(5);
+ly = 0.5*lx;
+
+Point(1) = { 0,  0, 0};
+Point(2) = {lx,  0, 0};
+Point(3) = {lx, ly, 0};
+Point(4) = { 0, ly, 0};
+
+Line(1) = {1,2};
+Line(2) = {2,3};
+Line(3) = {3,4};
+Line(4) = {4,1};
+
+Line Loop(1) = {1,2,3,4};
+Ruled Surface(1) = {1};
+Transfinite Surface(1) = {1,2,3,4};
+
+Recombine Surface(1);
+Transfinite Line{1,3} = nx+1;
+Transfinite Line{2,4} = ny+1;
+
+//Physical Line(1) = {1,2,3,4};
+Physical Surface(10) = {1};
+
+Physical Line(1) = {1}; // bottom
+Physical Line(2) = {2}; // right
+Physical Line(3) = {3}; // top
+Physical Line(4) = {4}; // left
+   

--- a/examples/AlfvenWave/input.prm
+++ b/examples/AlfvenWave/input.prm
@@ -1,0 +1,100 @@
+# Listing of Parameters
+# ---------------------
+
+# The input grid 
+set mesh type = gmsh
+set mesh file = grid.msh
+set degree = 2
+set basis = Pk
+set mapping = cartesian
+
+# Stabilization parameter
+set diffusion power       = 2.0
+set diffusion coefficient = 0.0
+
+# --------------------------------------------------
+# Boundary conditions
+# We may specify boundary conditions for up to MAX_BD boundaries.
+# Your .inp file should have these boundaries designated.
+# farfield supersonic inflow boundary
+subsection boundary_1
+   set type = periodic
+   set pair = 3
+   set direction = y
+end
+
+subsection boundary_2
+   set type = periodic
+   set pair = 4
+   set direction = x
+end
+
+subsection boundary_3
+   set type = periodic
+   set pair = 1
+   set direction = y
+end
+
+subsection boundary_4
+   set type = periodic
+   set pair = 2
+   set direction = x
+end
+
+# --------------------------------------------------
+# Initial Conditions
+# We set the initial conditions of the conservative variables.  These lines
+# are passed to the expression parsing function.  You should use x,y,z for
+# the coordinate variables.
+
+subsection initial condition
+   set function = alfven
+end
+
+# --------------------------------------------------
+# Time stepping control
+subsection time stepping
+  set time step type = global
+  set cfl = 0.9
+  set final time = 5.0
+  set nonlinear iterations = 1
+end
+
+subsection linear solver
+  set output         = quiet
+  set method         = rk3
+end
+
+# --------------------------------------------------
+# Output frequency and kind
+subsection output
+  set iter step      = 1
+  set schlieren plot = true
+  set format         = vtk #tecplot
+#  set compute angular momentum = 1
+end
+
+# --------------------------------------------------
+# Refinement control
+subsection refinement
+  set refinement = false # none only other option
+  set iter step  = 5
+  set shock value = 1.0
+  set shock levels = 3
+end
+
+# --------------------------------------------------
+# Flux parameters
+subsection flux
+ set flux = lxf
+end
+
+subsection limiter
+   set shock indicator = limiter
+   set type = none
+   set characteristic limiter = true
+   set positivity limiter = false
+   set M = 0
+   set beta = 2
+   set conserve angular momentum = false
+end

--- a/examples/AlfvenWave/input.prm
+++ b/examples/AlfvenWave/input.prm
@@ -4,8 +4,8 @@
 # The input grid 
 set mesh type = gmsh
 set mesh file = grid.msh
-set degree = 2
-set basis = Pk
+set degree = 0
+set basis = Qk
 set mapping = cartesian
 
 # Stabilization parameter
@@ -55,7 +55,7 @@ end
 # Time stepping control
 subsection time stepping
   set time step type = global
-  set cfl = 0.9
+  set cfl = 0.1
   set final time = 5.0
   set nonlinear iterations = 1
 end
@@ -63,12 +63,13 @@ end
 subsection linear solver
   set output         = quiet
   set method         = rk3
+  set add_powell_terms = true
 end
 
 # --------------------------------------------------
 # Output frequency and kind
 subsection output
-  set iter step      = 1
+  set iter step      = 20
   set schlieren plot = true
   set format         = vtk #tecplot
 #  set compute angular momentum = 1

--- a/src_mhd/assemble_explicit.cc
+++ b/src_mhd/assemble_explicit.cc
@@ -86,7 +86,7 @@ void ConservationLaw<dim>::integrate_cell_term_explicit
 
 	 // divB : This should be done better
 	 if((c>=MHDEquations<dim>::magnetic_component)&&
-	    (c<MHDEquations<dim>::density_component))
+	    (c<MHDEquations<dim>::magnetic_component + dim))
 	 {
 	   unsigned int d = c-MHDEquations<dim>::magnetic_component;
 	   divB += current_solution(dof_indices[i]) *
@@ -137,7 +137,7 @@ void ConservationLaw<dim>::integrate_cell_term_explicit
                 fe_v.JxW(point);
 	 
 	 // Powell terms WARNING: Check if it works
-	 F_i -= powellcoef[point][component_i] *
+	 F_i += powellcoef[point][component_i] *
                 fe_v.shape_value_component(i, point, component_i) *
                 fe_v.JxW(point) *
                 divB;

--- a/src_mhd/assemble_explicit.cc
+++ b/src_mhd/assemble_explicit.cc
@@ -215,7 +215,7 @@ void ConservationLaw<dim>::integrate_boundary_term_explicit
    //****************************************************
    
    typename MHDEquations<dim>::BoundaryKind boundCheck = MHDEquations<dim>::periodic;
-   if((boundary_kind==boundCheck))
+   if(boundary_kind == boundCheck)
    {
       // Find the neighbouring cell via map.find(key) and store the face_pair
       FacePair<dim,dim> face_pair;

--- a/src_mhd/claw.cc
+++ b/src_mhd/claw.cc
@@ -343,6 +343,8 @@ void ConservationLaw<dim>::setup_system ()
    right_hand_side.reinit 	(locally_owned_dofs, locally_relevant_dofs, mpi_communicator);
    newton_update.reinit 	(locally_owned_dofs, mpi_communicator);
    
+   //divB.reinit 		(locally_owned_dofs, mpi_communicator);
+   
    cell_average.resize 		(triangulation.n_active_cells(),
 							       Vector<double>(MHDEquations<dim>::n_components));
    

--- a/src_mhd/claw.h
+++ b/src_mhd/claw.h
@@ -265,6 +265,8 @@ private:
    LA::Vector<double>			    right_hand_side;
    LA::Vector<double>			    newton_update;
    
+   //LA::Vector<double>			    divB;
+   
    std::vector< dealii::Vector<double> >	    cell_average;  
    dealii::Vector<double>       dt;
    dealii::Vector<double>       mu_shock;

--- a/src_mhd/equation.cc
+++ b/src_mhd/equation.cc
@@ -217,9 +217,9 @@ compute_derived_quantities_vector (const std::vector<Vector<double> >           
            ExcInternalError());
    
    if (do_schlieren_plot == true)
-      Assert (computed_quantities[0].size() == dim+2, ExcInternalError())
+      Assert (computed_quantities[0].size() == dim+3, ExcInternalError())
       else
-         Assert (computed_quantities[0].size() == dim+1, ExcInternalError());
+         Assert (computed_quantities[0].size() == dim+2, ExcInternalError());
    
 
    for (unsigned int q=0; q<n_quadrature_points; ++q)
@@ -230,9 +230,10 @@ compute_derived_quantities_vector (const std::vector<Vector<double> >           
          computed_quantities[q](d) = uh[q](d) / density;
       
       computed_quantities[q](dim) = compute_pressure<double> (uh[q]);
-      
+      computed_quantities[q](dim+1) = duh[q][magnetic_component][0] +
+                                      duh[q][magnetic_component+1][1];
       if (do_schlieren_plot == true)
-         computed_quantities[q](dim+1) = duh[q][density_component] *
+         computed_quantities[q](dim+2) = duh[q][density_component] *
                                          duh[q][density_component];
    }
 }
@@ -251,6 +252,7 @@ MHDEquations<dim>::Postprocessor::get_names () const
   //names.push_back ("YMagnetic");
   //names.push_back ("ZMagnetic");
   names.push_back ("Pressure");
+  names.push_back ("divB");
 
   if (do_schlieren_plot == true)
     names.push_back ("schlieren_plot");
@@ -267,6 +269,9 @@ MHDEquations<dim>::Postprocessor::get_data_component_interpretation () const
     interpretation (dim,
 		    DataComponentInterpretation::component_is_part_of_vector);
 
+  interpretation.push_back (DataComponentInterpretation::
+			    component_is_scalar);
+  // divB
   interpretation.push_back (DataComponentInterpretation::
 			    component_is_scalar);
 
@@ -296,9 +301,9 @@ unsigned int
 MHDEquations<dim>::Postprocessor::n_output_variables () const
 {
   if (do_schlieren_plot == true)
-    return dim+2;
+    return dim+3;
   else
-    return dim+1;
+    return dim+2;
 }
 
 

--- a/src_mhd/equation.cc
+++ b/src_mhd/equation.cc
@@ -185,7 +185,7 @@ EulerEquations<dim>::Postprocessor::n_output_variables () const
 //***********************************************************************
 
 template <int dim>
-const double MHDEquations<dim>::gas_gamma = 1.4;
+const double MHDEquations<dim>::gas_gamma = 5.0/3.0;
 
 template <int dim>
 MHDEquations<dim>::Postprocessor::

--- a/src_mhd/equation.h
+++ b/src_mhd/equation.h
@@ -1615,13 +1615,15 @@ struct MHDEquations
    {
       std::vector<dealii::DataComponentInterpretation::DataComponentInterpretation>
       data_component_interpretation
-      (v_components, dealii::DataComponentInterpretation::component_is_part_of_vector);
+      (dim, dealii::DataComponentInterpretation::component_is_part_of_vector);
       data_component_interpretation
-      .push_back (dealii::DataComponentInterpretation::component_is_part_of_vector);
+      .push_back (dealii::DataComponentInterpretation::component_is_scalar);
       data_component_interpretation
-      .push_back (dealii::DataComponentInterpretation::component_is_part_of_vector);
+      .push_back (dealii::DataComponentInterpretation::component_is_scalar);
       data_component_interpretation
-      .push_back (dealii::DataComponentInterpretation::component_is_part_of_vector);
+      .push_back (dealii::DataComponentInterpretation::component_is_scalar);
+      data_component_interpretation
+      .push_back (dealii::DataComponentInterpretation::component_is_scalar);
       data_component_interpretation
       .push_back (dealii::DataComponentInterpretation::component_is_scalar);
       data_component_interpretation
@@ -1659,12 +1661,12 @@ struct MHDEquations
    compute_magnetic_pressure (const InputVector &W)
    {
       number magnetic_pressure = 0;
-      if (model == 0)
-	return magnetic_pressure;
       for (unsigned int d=0; d<v_components; ++d)
          magnetic_pressure += (*(W.begin()+magnetic_component+d))*
 			      (*(W.begin()+magnetic_component+d));
       magnetic_pressure*=0.5;
+      /*if(isnan(magnetic_pressure))
+	std::cout<<"\n\t01="<<W[magnetic_component]<<"\t02="<<W[magnetic_component+1]<<"\t03="<<W[magnetic_component+2];//*/
       return magnetic_pressure;
    }
    
@@ -1676,11 +1678,14 @@ struct MHDEquations
    number
    compute_pressure (const InputVector &W)
    {
-
-      return ((gas_gamma-1.0) *
-              (*(W.begin() + energy_component) -
-               compute_kinetic_energy<number>(W) -
-               compute_magnetic_pressure<number>(W)));
+     number pressure=0;
+     number m_pressure = compute_magnetic_pressure<number>(W);
+     number kinetic = compute_kinetic_energy<number>(W);
+     pressure = ((gas_gamma-1.0)*( *(W.begin() + energy_component)
+                - kinetic
+		- m_pressure));
+     
+     return pressure;
    }
    
    //---------------------------------------------------------------------------
@@ -1718,8 +1723,7 @@ struct MHDEquations
      typedef typename InputVector::value_type number;
      number B_n = std::fabs(*(W.begin()+magnetic_component));
      for (unsigned int i = 1; i<v_components; i++)
-       B_n = std::min(B_n, std::fabs(*(W.begin()+magnetic_component+i)));
-     
+       B_n = std::min(B_n, std::fabs(*(W.begin()+magnetic_component+i)));//*/
      const number C_A = B_n/std::sqrt((*(W.begin()+density_component)));
      //std::cout<<"\nAlfven speed: "<<C_A<<"\n";
      return C_A;
@@ -1763,6 +1767,8 @@ struct MHDEquations
 
       const number pressure = compute_pressure<number> (W);
       const number C_a = alfven_speed(W);
+      if(C_a<1e-12)
+	return 0.0;
       const number a_2 = gas_gamma * pressure / (*(W.begin()+density_component));
       number b_2 = 0;
       for(unsigned int d=0; d<v_components; d++)
@@ -1877,14 +1883,20 @@ struct MHDEquations
 		   const dealii::Tensor<1,dim> &normal)
    {
       typedef typename InputVector::value_type number;
+      
+      const number pressure = compute_pressure<number> (W);
+      if(pressure<0)
+	std::cout<<"\n\t  pressure is negative at VMaxEigen W=["
+		 <<W[0]<<", "<<W[1]<<", "<<W[2]<<", "<<W[3]<<", "
+		 <<W[4]<<", "<<W[5]<<", "<<W[6]<<", "<<W[7]<<"]";
+      const number sonic = std::sqrt(gas_gamma * pressure / (*(W.begin()+density_component)));
 
       number velocity = 0;
-      for(unsigned int  d=0; d < v_components; d++)
-	velocity += (*(W.begin()+momentum_component+d)) * (*(W.begin()+momentum_component+d));
-      velocity = std::sqrt(velocity) / (*(W.begin()+density_component));
+      for(unsigned int  d=0; d < dim; d++)
+	velocity += (*(W.begin()+momentum_component+d)) * normal[d];
+      velocity /= (*(W.begin()+density_component)); //std::sqrt(velocity)
 
-      number C_f = fast_speed(W, normal);
-      return fabs(velocity) + fabs(C_f);
+      return std::fabs(velocity)+sonic;
    }
    
    // In case we need to compute it over the mean values
@@ -1893,15 +1905,17 @@ struct MHDEquations
    typename InputVector::value_type
    max_eigenvalue (const InputVector &W)
    {
-      typedef typename InputVector::value_type number;
-
-      number velocity = 0;
-      for(unsigned int  d=0; d < v_components; d++)
-	velocity += (*(W.begin()+momentum_component+d)) * (*(W.begin()+momentum_component+d));
-      velocity = std::sqrt(velocity) / (*(W.begin()+density_component));
-
-      number C_f = fast_speed(W);
-      return fabs(velocity) + fabs(C_f);
+     typedef typename InputVector::value_type number;
+     const number pressure = compute_pressure<number> (W);
+     const number m_pressure = compute_magnetic_pressure<number>(W);
+     
+     number velocity = 0;
+     for (unsigned int d=0; d<dim; ++d)
+       velocity += *(W.begin()+d) *
+		   *(W.begin()+d);
+     velocity = std::sqrt(velocity) / (*(W.begin()+density_component));
+     
+     return velocity + std::sqrt((gas_gamma * pressure + 2*m_pressure) / (*(W.begin()+density_component)));
    }
    
    //---------------------------------------------------------------------------
@@ -1913,22 +1927,19 @@ struct MHDEquations
    max_eigenvalue_normal (const InputVector        &W,
                    const dealii::Tensor<1,dim> &normal)
    {
-      typedef typename InputVector::value_type number;
+     typedef typename InputVector::value_type number;
+     const number pressure = compute_pressure<number> (W);
+     const number m_pressure = compute_magnetic_pressure<number>(W);
+     
+     const number sonic = std::sqrt((gas_gamma * pressure + 2*m_pressure) / (*(W.begin()+density_component)));
+     
+     number velocity = 0;
+     for (unsigned int d=0; d<dim; ++d)
+       velocity += *(W.begin()+d) * normal[d];
+     
+     velocity /=  (*(W.begin()+density_component));
+     return std::fabs(velocity) + sonic;
       
-      check_speeds_order(W, normal);
-
-      number velocity = 0;
-      for(unsigned int d=0; d<dim; ++d)
-	velocity += (*(W.begin()+momentum_component+d)) * normal[d];
-      velocity /=  (*(W.begin()+density_component));
-      /*if(isnan(velocity))
-	std::cout<<"\n\t Velocity is nan in the max eigenvalue normal density = "<<W[density_component];//*/
-
-      number C_f = fast_speed(W,normal);
-      /*if(isnan(C_f))
-	std::cout<<"\n\t Fast speed is nan in the max eigenvalue normal";//*/
-
-      return fabs(velocity) + fabs(C_f);
    }
    
    // In case we need to compute it over the mean values
@@ -1937,20 +1948,11 @@ struct MHDEquations
    typename InputVector::value_type
    sound_speed (const InputVector &W)
    {
-      typedef typename InputVector::value_type number;
-      number C_f=0;
-      
-      if(model == 0)
-      {
-	const number pressure = compute_pressure<number> (W);
-	return std::sqrt(gas_gamma * pressure / (*(W.begin()+density_component)));
-      }
-      else
-      {
-	check_speeds_order(W);
-	C_f = fast_speed(W);
-	return  fabs(C_f);
-      }
+     typedef typename InputVector::value_type number;
+     const number pressure = compute_pressure<number> (W);
+     const number m_pressure = compute_magnetic_pressure<number>(W);
+     return std::sqrt((gas_gamma * pressure + 2*m_pressure) / (*(W.begin()+density_component)));
+     
    }
    
    //---------------------------------------------------------------------------
@@ -1969,48 +1971,37 @@ struct MHDEquations
       // momentum terms:
       const number pressure = compute_pressure<number> (W);
       const number magnetic_pressure = compute_magnetic_pressure<number> (W);
-      number density_1=1/W[density_component];
+      //const number density_1=1.0/W[density_component];
       
       // Compute the flux function for the momentum
       for (unsigned int i=0; i<v_components; ++i)
       {
 	for (unsigned int j=0; j<dim; ++j)
 	{
-            flux[momentum_component+i][j] = W[momentum_component+i]*W[momentum_component+j]*density_1
+            flux[momentum_component+i][j] = W[momentum_component+i]*W[momentum_component+j]/W[density_component]
 					    - W[magnetic_component+i]*W[magnetic_component+j];
-	if(i==j)
+	if(j==i)
 	  flux[momentum_component+i][j] += pressure + magnetic_pressure;
 	
-	if(isnan(flux[momentum_component+i][momentum_component+j]))
-	  std::cout<<"\n\t flux function is NaN";//*/
-	
+	if(isnan(flux[momentum_component+i][j]))
+	  std::cout<<"\n\t flux function is NaN, Pressure="<<pressure<<", ma_press="<<magnetic_pressure
+		   <<", moment="<<W[momentum_component+i]<<", density_1="<<W[density_component];//*/
 	}
       }
       
       // Compute the flux function for the magnetic field
-      if(model==0)
-      {
-	for (unsigned int i=magnetic_component; i<density_component; ++i)
-	{
-	  for (unsigned int e=0; e<dim; ++e)
-	  {
-	    flux[i][e] = 0;
-	  }
-	}
-      }
-      else
-      {
-
 	for (unsigned int i=0; i<v_components; ++i)
 	{
 	  for (unsigned int j=0; j<dim; ++j)
 	  {
-	    flux[magnetic_component+i][j] = W[momentum_component+i] * W[magnetic_component+j]
-					    - W[momentum_component+j] * W[magnetic_component+i];
-	    flux[magnetic_component+i][j] /= W[density_component];
+	    flux[magnetic_component+i][j] = (W[momentum_component+j] * W[magnetic_component+i]
+					    - W[momentum_component+i] * W[magnetic_component+j])
+					    / W[density_component];
+	    if(isnan(flux[magnetic_component+i][j]))
+	      std::cout<<"\n\t flux function is NaN, moment="<<W[momentum_component+i]
+		       <<", mag="<<W[magnetic_component+i]<<", density_1="<<W[density_component];//*/
 	  }
 	}
-      }
       
       // Flux function for the conservation of mass
       for (unsigned int i=0; i<dim; ++i)
@@ -2020,14 +2011,11 @@ struct MHDEquations
       for (unsigned int i=0; i<v_components;++i)
 	udotB += W[momentum_component+i] * W[magnetic_component+i];
       udotB/=W[density_component];
-      
-      if(model==0)
-	udotB = 0;
 
       // Flux function for the conservation of energy
       for (unsigned int i=0; i<dim; ++i)
-         flux[energy_component][i] = W[momentum_component+i] * density_1 *
-                                     (W[energy_component] + pressure + magnetic_pressure)
+         flux[energy_component][i] = W[momentum_component+i] * ( W[energy_component]
+				     + pressure + magnetic_pressure) / W[density_component]
                                      - W[magnetic_component+i]*udotB;
    }
    
@@ -2037,7 +2025,7 @@ struct MHDEquations
    template <typename InputVector, typename number>
    static
    void powell_terms (const InputVector &W,
-                          number (&flux)[n_components]) //, number divB)
+                          number (&flux)[n_components])
    {
      number density_1=1/W[density_component];
      number velocity;
@@ -2049,13 +2037,11 @@ struct MHDEquations
        velocity = W[momentum_component+i]*density_1;
        
        // Powell terms for the momentum components
-       flux[momentum_component + i] = W[magnetic_component + i]; //*divB;
+       flux[momentum_component + i] = W[magnetic_component + i];
        // Powell terms for the magnetic components
        flux[magnetic_component + i] = velocity;
-     //}
-     //for (unsigned int i=0; i<dim; ++i)
-     //{ 
-       flux[energy_component] += W[momentum_component+i]*density_1*W[magnetic_component + i]; //velocity
+       // Powell terms for the energy component
+       flux[energy_component] += velocity*W[magnetic_component + i];
      }
      
    }
@@ -2218,14 +2204,94 @@ struct MHDEquations
       // Maximum eigenvalue at cell face
       number lambda_plus = max_eigenvalue_normal(Aplus, normal);
       number lambda_minus = max_eigenvalue_normal(Aminus, normal);
-      number lambda = std::max(lambda_plus, lambda_minus);//*/
+      number lambda = std::max(lambda_plus, lambda_minus);
+      //number lambda=1;
       if(isnan(lambda)||isnan(lambda_minus)||isnan(lambda_plus))
 	std::cout<<"\n \t Numerical flux problem lambda = "<<lambda<<"\t lambda_minus = "<<lambda_minus
-		 << "\t lambda_plus = "<< lambda_plus;//*/
+		 << "\t lambda_plus = "<< lambda_plus;
+      
+      // Dissipation flux
+      
+      for (unsigned int c=0; c<n_components; ++c)
+         normal_flux[c] += 0.5 * lambda  * (Wplus[c] - Wminus[c]);//*/
+	 
+      /*typedef typename InputVector::value_type number;
+
+      // Normal velocity
+      number vdotn_plus=0, vdotn_minus=0, bdotn_plus=0, bdotn_minus=0;
+      
+      for(unsigned int d=0; d<dim; ++d)
+      {
+         vdotn_plus  += Wplus[d]  * normal[d];
+         vdotn_minus += Wminus[d] * normal[d];
+	 bdotn_plus  += Wplus[magnetic_component+d]  * normal[d];
+         bdotn_minus += Wminus[magnetic_component+d] * normal[d];
+      }
+      
+      vdotn_plus  /= Wplus [density_component];
+      vdotn_minus /= Wminus[density_component];
+      
+      // pressure
+      number p_plus, p_minus, mp_plus, mp_minus;
+
+      p_plus  = compute_pressure<number> (Wplus);
+      mp_plus = compute_magnetic_pressure<number> (Wplus);
+      p_minus = compute_pressure<number> (Wminus);
+      mp_minus = compute_magnetic_pressure<number> (Wminus);
+      
+      // Maximum eigenvalue at cell face
+      number lambda_plus = max_eigenvalue (Aplus, normal);
+      number lambda_minus = max_eigenvalue (Aminus, normal);
+      number lambda = std::max(lambda_plus, lambda_minus);
+      if(isnan(lambda))
+ 	std::cout<<"\n\t Lambda NaN";
+      
+      // Momentum flux
+      number normal_p[v_components];
+      for(unsigned int d=0;d<dim;d++)
+	normal_p[d] =normal[d];
+      normal_p[dim]=0;
+
+      for (unsigned int i=0; i<v_components; ++i)
+      {
+            normal_flux[i] = 0.5 * ( (p_plus+mp_plus)*normal_p[i] + Wplus[i]*vdotn_plus
+				- Wplus[magnetic_component+i]*bdotn_plus +
+				(p_minus+mp_minus) * normal_p[i] + Wminus[i]*vdotn_minus
+				- Wminus[magnetic_component+i]*bdotn_minus);
+      }
+      
+      // Magnetic flux
+      for (unsigned int i=0; i<v_components; ++i)
+      {
+	normal_flux[magnetic_component+i] = 0.5*(vdotn_plus * Wplus[magnetic_component+i] -
+					    Wplus[momentum_component+i] * bdotn_plus/Wplus[density_component] +
+					    vdotn_minus * Wminus[magnetic_component+i]) -
+					    Wminus[momentum_component+i] * bdotn_minus/Wminus[density_component];
+      }
+
+      // Density flux
+      normal_flux[density_component] = 0.5 * (Wplus [density_component] * vdotn_plus +
+                                              Wminus[density_component] * vdotn_minus);
+      
+      // Energy flux
+      number udotBplus = 0, udotBminus=0;
+      for (unsigned int i=0; i<v_components;++i)
+      {
+	udotBplus += Wplus[momentum_component+i] * Wplus[magnetic_component+i];
+	udotBminus += Wminus[momentum_component+i] * Wminus[magnetic_component+i];
+      }
+      udotBplus/=Wplus[density_component];
+      udotBminus/=Wminus[density_component];
+      
+      normal_flux[energy_component] = 0.5*(vdotn_plus*(Wplus[energy_component] + p_plus + mp_plus)
+                                      - bdotn_plus*udotBplus
+				      + vdotn_minus*(Wminus[energy_component] + p_minus + mp_minus)
+                                      - bdotn_minus*udotBminus);
+      
       
       // Dissipation flux
       for (unsigned int c=0; c<n_components; ++c)
-         normal_flux[c] += 0.5 * lambda * (Wplus[c] - Wminus[c]);
+         normal_flux[c] += 0.5 * lambda * (Wplus[c] - Wminus[c]);//*/
    }
    
    // --------------------------------------------------------------------------

--- a/src_mhd/equation.h
+++ b/src_mhd/equation.h
@@ -1587,7 +1587,7 @@ struct MHDEquations
    static const unsigned int momentum_component	      = 0;
    static const unsigned int magnetic_component       = v_components;
    
-   static const unsigned int model = 0;
+   static const unsigned int model = 1;
    
    
    
@@ -1719,6 +1719,7 @@ struct MHDEquations
      for (unsigned int i = 0; i<v_components; i++)
        B_n += std::pow(*(W.begin()+magnetic_component+i),2);
      const number C_A = std::sqrt(B_n/(*(W.begin()+density_component)));
+     //std::cout<<"\nAlfven speed: "<<C_A<<"\n";
      return C_A;
    }
    
@@ -1738,7 +1739,7 @@ struct MHDEquations
       const number a_2 = gas_gamma * pressure / (*(W.begin()+density_component));
       number b_2 = 0;
       for(unsigned int d=0; d<v_components; d++)
-	b_2 = (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
+	b_2 += (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
       b_2 /= (*(W.begin()+density_component));
 
       number C_s = std::sqrt( 0.5*(a_2 + b_2 - std::sqrt((a_2+b_2)*(a_2+b_2) - 4*a_2*C_a)));
@@ -1758,7 +1759,7 @@ struct MHDEquations
       const number a_2 = gas_gamma * pressure / (*(W.begin()+density_component));
       number b_2 = 0;
       for(unsigned int d=0; d<v_components; d++)
-	b_2 = (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
+	b_2 += (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
       b_2 /= (*(W.begin()+density_component));
 
       number C_s = std::sqrt( 0.5*(a_2 + b_2 - std::sqrt((a_2+b_2)*(a_2+b_2) - 4*a_2*C_a)));
@@ -1785,7 +1786,7 @@ struct MHDEquations
 
       number b_2 = 0;
       for(unsigned int d=0; d<v_components; d++)
-	b_2 = (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
+	b_2 += (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
       b_2 /= (*(W.begin()+density_component));
       //if(isnan(b_2)) std::cout<<"\n\t b_2 is nan in the fast speed";
 
@@ -1812,7 +1813,7 @@ struct MHDEquations
       const number a_2 = gas_gamma * pressure / (*(W.begin()+density_component));
       number b_2 = 0;
       for(unsigned int d=0; d<v_components; d++)
-	b_2 = (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
+	b_2 += (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
       b_2 /= (*(W.begin()+density_component));
 
       number C_f = std::sqrt( 0.5*(a_2 + b_2 + std::sqrt((a_2+b_2)*(a_2+b_2) - 4*a_2*C_a)));
@@ -1888,7 +1889,7 @@ struct MHDEquations
    sound_speed (const InputVector &W)
    {
       typedef typename InputVector::value_type number;
-      number C_f;
+      number C_f=0;
       
       if(model == 0)
       {

--- a/src_mhd/equation.h
+++ b/src_mhd/equation.h
@@ -2187,7 +2187,7 @@ struct MHDEquations
     typename InputVector::value_type (&normal_flux)[n_components]
    )
    {
-      typedef typename InputVector::value_type number;
+      /*typedef typename InputVector::value_type number;
       
       number fluxplus[n_components][dim], fluxminus[n_components][dim];
       compute_flux_matrix (Wplus, fluxplus);
@@ -2215,7 +2215,7 @@ struct MHDEquations
       for (unsigned int c=0; c<n_components; ++c)
          normal_flux[c] += 0.5 * lambda  * (Wplus[c] - Wminus[c]);//*/
 	 
-      /*typedef typename InputVector::value_type number;
+      typedef typename InputVector::value_type number;
 
       // Normal velocity
       number vdotn_plus=0, vdotn_minus=0, bdotn_plus=0, bdotn_minus=0;
@@ -2240,8 +2240,8 @@ struct MHDEquations
       mp_minus = compute_magnetic_pressure<number> (Wminus);
       
       // Maximum eigenvalue at cell face
-      number lambda_plus = max_eigenvalue (Aplus, normal);
-      number lambda_minus = max_eigenvalue (Aminus, normal);
+      number lambda_plus = max_eigenvalue_normal (Aplus, normal);
+      number lambda_minus = max_eigenvalue_normal (Aminus, normal);
       number lambda = std::max(lambda_plus, lambda_minus);
       if(isnan(lambda))
  	std::cout<<"\n\t Lambda NaN";

--- a/src_mhd/equation.h
+++ b/src_mhd/equation.h
@@ -1979,6 +1979,34 @@ struct MHDEquations
    }
    
    //---------------------------------------------------------------------------
+   // Compute cartesian components of flux
+   //---------------------------------------------------------------------------
+   template <typename InputVector, typename number>
+   static
+   void powell_terms (const InputVector &W,
+                          number (&flux)[n_components]) //, number divB)
+   {
+     number density_1=1/W[density_component];
+     number velocity;
+     
+     flux[energy_component] = 0;
+     for (unsigned int i=0; i<v_components; ++i)
+     {
+       velocity = W[momentum_component+i]*density_1;
+       
+       // Powell terms for the momentum components
+       flux[momentum_component + i] = W[magnetic_component + i]; //*divB;
+       // Powell terms for the magnetic components
+       flux[magnetic_component + i] = velocity; //*divB;
+       
+       flux[energy_component] += velocity * W[magnetic_component + i];
+     }
+     // Powell terms for the energy component
+     //flux[energy_component] *= divB;
+     
+   }
+   
+   //---------------------------------------------------------------------------
    // Compute flux along normal
    //---------------------------------------------------------------------------
    /*template <typename InputVector, typename number>

--- a/src_mhd/equation.h
+++ b/src_mhd/equation.h
@@ -1644,7 +1644,8 @@ struct MHDEquations
       number kinetic_energy = 0;
       // Momentum variables
       for (unsigned int d=0; d<v_components; ++d)
-         kinetic_energy += *(W.begin()+momentum_component+d) * *(W.begin()+momentum_component+d);
+         kinetic_energy += (*(W.begin()+momentum_component+d))*
+			   (*(W.begin()+momentum_component+d));
       kinetic_energy *= 0.5/(*(W.begin() + density_component));
       return kinetic_energy;
    }
@@ -1661,8 +1662,8 @@ struct MHDEquations
       if (model == 0)
 	return magnetic_pressure;
       for (unsigned int d=0; d<v_components; ++d)
-         magnetic_pressure += *(W.begin()+magnetic_component+d) *
-                              *(W.begin()+magnetic_component+d);
+         magnetic_pressure += (*(W.begin()+magnetic_component+d))*
+			      (*(W.begin()+magnetic_component+d));
       magnetic_pressure*=0.5;
       return magnetic_pressure;
    }
@@ -1746,9 +1747,9 @@ struct MHDEquations
       number radical1 = (a_2+b_2)*(a_2+b_2) - 4*a_2*C_a*C_a;
       number radical2 =  0.5*(a_2 + b_2 - std::sqrt(radical1));
       number C_s = std::sqrt(radical2);
-      if(isnan(C_s))
-	std::cout<<"\n\t The Slow speed is NaN. mx="<<*(W.begin())<<", my="<<*(W.begin()+1)<<", e="<<*(W.begin()+energy_component)
-		 <<", bx="<<*(W.begin()+dim)<<", by="<<*(W.begin()+1)<<", density="<<*(W.begin()+density_component);//*/
+      /*if(isnan(C_s))
+	std::cout<<"\n\t The Slow speed is NaN. r1="<<radical1<<", r2="<<radical2<<", C_a="<<C_a
+		 <<", a2="<<a_2<<", b2="<<b_2;//*/
       return C_s;
    }
    
@@ -1768,12 +1769,12 @@ struct MHDEquations
 	b_2 += (*(W.begin()+magnetic_component+d))* (*(W.begin()+magnetic_component+d));
       b_2 /= (*(W.begin()+density_component));
 
-            number radical1 = (a_2+b_2)*(a_2+b_2) - 4*a_2*C_a*C_a;
+      number radical1 = (a_2+b_2)*(a_2+b_2) - 4*a_2*C_a*C_a;
       number radical2 =  0.5*(a_2 + b_2 - std::sqrt(radical1));
       number C_s = std::sqrt(radical2);
-      if(isnan(C_s))
-	std::cout<<"\n\t The Slow speed is NaN. mx="<<*(W.begin())<<", my="<<*(W.begin()+1)<<", e="<<*(W.begin()+energy_component)
-		 <<", bx="<<*(W.begin()+dim)<<", by="<<*(W.begin()+1)<<", density="<<*(W.begin()+density_component);//*/
+      /*if(isnan(C_s))
+	std::cout<<"\n\t The Slow speed is NaN. r1="<<radical1<<", r2="<<radical2<<", C_a="<<C_a
+		 <<", a2="<<a_2<<", b2="<<b_2;//*/
       return C_s;
    }
    
@@ -2021,7 +2022,7 @@ struct MHDEquations
       udotB/=W[density_component];
       
       if(model==0)
-	number udotB = 0;
+	udotB = 0;
 
       // Flux function for the conservation of energy
       for (unsigned int i=0; i<dim; ++i)

--- a/src_mhd/ic.cc
+++ b/src_mhd/ic.cc
@@ -109,12 +109,12 @@ template <int dim>
 void AlfvenWaves<dim>::vector_value (const Point<dim> &p,
                                       Vector<double>   &values) const
 {
-   double theta = 0; //std::atan(2.0);
+   double theta = std::atan(0.5);
    const double gamma = MHDEquations<dim>::gas_gamma;
    double a_2pix1 = 2*M_PI*(p[0]*std::cos(theta) + p[1]*std::sin(theta));
    // Parallel (p) and Orthogonal (o) Variables
    double Bp=1.0,
-	  Bo=0.05*std::sin(a_2pix1),
+	  Bo=0.1*std::sin(a_2pix1),
 	  Vp=0.0,
 	  Vo=0.1*std::sin(a_2pix1);
    // Cartesian coordinates

--- a/src_mhd/ic.cc
+++ b/src_mhd/ic.cc
@@ -111,11 +111,14 @@ void AlfvenWaves<dim>::vector_value (const Point<dim> &p,
 {
    double theta = atan(2.0);
    const double gamma = MHDEquations<dim>::gas_gamma;
-   double x1= p[0]*std::cos(theta) + p[1]*std::sin(theta);
-   double a_2pix1 = 2*M_PI*x1;
-   double rho = 1, pre = 0.1,
-	  vex = 0, vey = 0.1*std::sin(a_2pix1), vez = 0.1*std::cos(a_2pix1),
-	  bx  = 1, by  = 0.1*std::sin(a_2pix1), bz  = 0.1*std::cos(a_2pix1);
+   double a_2pix1 = 2*M_PI*(p[0]*std::cos(theta) + p[1]*std::sin(theta));
+   double rho = 1.0, pre = 0.1,
+	  vex = 0.0,
+	  vey = 0.1*std::sin(a_2pix1),
+	  vez = 0.1*std::cos(a_2pix1),
+	  bx  = 1.0,
+	  by  = 0.1*std::sin(a_2pix1),
+	  bz  = 0.1*std::cos(a_2pix1);
    
    values[MHDEquations<dim>::momentum_component]   = rho * vex;
    values[MHDEquations<dim>::momentum_component+1] = rho * vey;

--- a/src_mhd/ic.cc
+++ b/src_mhd/ic.cc
@@ -109,15 +109,21 @@ template <int dim>
 void AlfvenWaves<dim>::vector_value (const Point<dim> &p,
                                       Vector<double>   &values) const
 {
-   double theta = atan(2.0);
+   double theta = 0; //std::atan(2.0);
    const double gamma = MHDEquations<dim>::gas_gamma;
    double a_2pix1 = 2*M_PI*(p[0]*std::cos(theta) + p[1]*std::sin(theta));
+   // Parallel (p) and Orthogonal (o) Variables
+   double Bp=1.0,
+	  Bo=0.05*std::sin(a_2pix1),
+	  Vp=0.0,
+	  Vo=0.1*std::sin(a_2pix1);
+   // Cartesian coordinates
    double rho = 1.0, pre = 0.1,
-	  vex = 0.0,
-	  vey = 0.1*std::sin(a_2pix1),
+	  vex = Vp*std::cos(theta) - Vo*std::sin(theta),
+	  vey = Vp*std::sin(theta) + Vo*std::cos(theta),
 	  vez = 0.1*std::cos(a_2pix1),
-	  bx  = 1.0,
-	  by  = 0.1*std::sin(a_2pix1),
+	  bx  = Bp*std::cos(theta) - Bo*std::sin(theta),
+	  by  = Bp*std::sin(theta) + Bo*std::cos(theta),
 	  bz  = 0.1*std::cos(a_2pix1);
    
    values[MHDEquations<dim>::momentum_component]   = rho * vex;

--- a/src_mhd/ic.h
+++ b/src_mhd/ic.h
@@ -1,6 +1,8 @@
 #ifndef __IC_H__
 #define __IC_H__
 
+//#include <cmath>
+
 #include <deal.II/base/function.h>
 #include <deal.II/lac/vector.h>
 
@@ -88,6 +90,18 @@ private:
    double beta, Rc;
    double a1, a2;
    double x[3], y[3];
+};
+
+//------------------------------------------------------------------------
+// Polarized Alfven  waves
+//------------------------------------------------------------------------
+template <int dim>
+class AlfvenWaves : public dealii::Function<dim>
+{
+public:
+   AlfvenWaves () : dealii::Function<dim>(MHDEquations<dim>::n_components){}
+   virtual void vector_value (const dealii::Point<dim>  &p,
+                              dealii::Vector<double>  &values) const;
 };
 
 //------------------------------------------------------------------------

--- a/src_mhd/parameters.cc
+++ b/src_mhd/parameters.cc
@@ -15,7 +15,7 @@ namespace Parameters
                            Patterns::Selection("quiet|verbose"),
                            "State whether output from solver runs should be printed. "
                            "Choices are <quiet|verbose>.");
-         prm.declare_entry("model", "euler",
+         prm.declare_entry("model", "mhd",
                            Patterns::Selection("euler|mhd"),
                            "Select the system of equations to solve "
                            "Choices are <euler|mhd>.");

--- a/src_mhd/parameters.cc
+++ b/src_mhd/parameters.cc
@@ -430,7 +430,7 @@ namespace Parameters
       prm.enter_subsection("initial condition");
       {
          prm.declare_entry("function", "none",
-                           Patterns::Selection("none|rt|isenvort|vortsys"),
+                           Patterns::Selection("none|rt|isenvort|vortsys|alfven"),
                            "function for initial condition");
          
          for (unsigned int di=0; di<MHDEquations<dim>::n_components; ++di)

--- a/src_mhd/parameters.cc
+++ b/src_mhd/parameters.cc
@@ -19,7 +19,10 @@ namespace Parameters
                            Patterns::Selection("euler|mhd"),
                            "Select the system of equations to solve "
                            "Choices are <euler|mhd>.");
-	     prm.declare_entry("method", "rk3",
+         prm.declare_entry("add_powell_terms", "false",
+                           Patterns::Bool(),
+                           "Whether adding or not  Powell terms to the numerical scheme ");
+	 prm.declare_entry("method", "rk3",
                            Patterns::Selection("gmres|direct|umfpack|rk3|mood"),
                            "The kind of solver for the linear system. "
                            "Choices are <gmres|direct|umfpack|rk3|mood>.");
@@ -63,7 +66,7 @@ namespace Parameters
             model = euler;
          if (eq == "mhd")
             model = mhd;
-         
+
          const std::string sv = prm.get("method");
          if (sv == "direct")
          {
@@ -91,6 +94,7 @@ namespace Parameters
             implicit = false;
          }
          
+         add_powell_terms= prm.get_bool ("add_powell_terms");
          linear_residual = prm.get_double("residual");
          max_iterations  = prm.get_integer("max iters");
          ilut_fill       = prm.get_double("ilut fill");

--- a/src_mhd/parameters.h
+++ b/src_mhd/parameters.h
@@ -368,7 +368,6 @@ namespace Parameters
    {
       static const unsigned int max_n_boundaries = 10;
       
-
       // In case of periodic boundary conditions
       bool is_periodic = 0;
       std::string direction;

--- a/src_mhd/parameters.h
+++ b/src_mhd/parameters.h
@@ -165,6 +165,9 @@ namespace Parameters
       enum System_model {euler, mhd};
       System_model model;
       
+      // Add Powell terms flag
+      bool add_powell_terms;
+      
       double linear_residual;
       int max_iterations;
       
@@ -365,6 +368,7 @@ namespace Parameters
    {
       static const unsigned int max_n_boundaries = 10;
       
+
       // In case of periodic boundary conditions
       bool is_periodic = 0;
       std::string direction;


### PR DESCRIPTION
- A polarized Alfvèn wave test case was added, in which no discontinuities in the solution are developed.
- Powell terms are added to correct instabilities resulting from the violation of the divergence free condition in the magnetic field.
- Some bugs were corrected in the computation of the Flux function and numerical flux related to the indexes in the tensorial product at the  momentum and magnetic field equations.
- Time stepping now depends on the maximum value possible for the fast speed C_f (sqrt((gamma*P+B^2)/rho))